### PR TITLE
Use defaultValue

### DIFF
--- a/library/src/main/java/com/kunzisoft/androidclearchroma/ChromaPreferenceCompat.java
+++ b/library/src/main/java/com/kunzisoft/androidclearchroma/ChromaPreferenceCompat.java
@@ -108,8 +108,17 @@ public class ChromaPreferenceCompat extends DialogPreference {
 
     @Override
     protected void onSetInitialValue(boolean restorePersistedValue, Object defaultValue) {
-        super.onSetInitialValue(restorePersistedValue, defaultValue);
-        color = getPersistedInt(color);
+        if (restorePersistedValue) {
+            color = getPersistedInt(color);
+        } else {
+            color = (int) defaultValue;
+            persistInt(color);
+        }
+    }
+
+    @Override
+    protected Object onGetDefaultValue(TypedArray a, int index) {
+        return Color.parseColor(a.getString(index));
     }
 
     @Override

--- a/sample/src/main/java/com/kunzisoft/androidclearchroma/sample/MainActivity.java
+++ b/sample/src/main/java/com/kunzisoft/androidclearchroma/sample/MainActivity.java
@@ -10,6 +10,7 @@ import android.support.annotation.ColorInt;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.preference.PreferenceManager;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.AdapterView;
@@ -51,6 +52,9 @@ public class MainActivity extends AppCompatActivity implements OnColorSelectedLi
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        // Load defaultValues from prefs_v7.xml
+        PreferenceManager.setDefaultValues(this, R.xml.prefs_v7, false);
 
         toolbar = (Toolbar) findViewById(R.id.toolbar);
         textView = (TextView) findViewById(R.id.text_view);

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#3F51B5</color>
     <color name="colorPrimaryDark">#303F9F</color>
     <color name="colorAccent">#3e4f9e</color>
+    <color name="defaultPreferenceColour">#ff00ff</color>
 </resources>

--- a/sample/src/main/res/xml/prefs_v7.xml
+++ b/sample/src/main/res/xml/prefs_v7.xml
@@ -1,4 +1,4 @@
-<PreferenceScreen
+<android.support.v7.preference.PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
@@ -13,7 +13,7 @@
         android:title="ARGB sample"
         android:summary="[color]"
         app:chromaColorMode="ARGB"
-        app:chromaInitialColor="@android:color/black"/>
+        android:defaultValue="@android:color/black"/>
 
     <com.kunzisoft.androidclearchroma.ChromaPreferenceCompat
         android:key="argbhex"
@@ -21,20 +21,20 @@
         android:summary="ARGB and HEX [color]"
         app:chromaColorMode="ARGB"
         app:chromaIndicatorMode="HEX"
-        app:chromaInitialColor="#ae4f4f"/>
+        android:defaultValue="#ae4f4f"/>
 
     <com.kunzisoft.androidclearchroma.ChromaPreferenceCompat
         android:key="hsv"
         android:title="HSV sample"
         app:chromaColorMode="HSV"
-        app:chromaInitialColor="#649e65"/>
+        android:defaultValue="#649e65"/>
 
     <com.kunzisoft.androidclearchroma.ChromaPreferenceCompat
         android:key="roundedquare"
         android:title="ARGB sample with rounded square sample"
         app:chromaShapePreview="ROUNDED_SQUARE"
         app:chromaColorMode="ARGB"
-        app:chromaInitialColor="#ffee00"/>
+        android:defaultValue="#ffee00"/>
 
     <com.kunzisoft.androidclearchroma.ChromaPreferenceCompat
         android:key="customsummary"
@@ -42,6 +42,6 @@
         android:summary="Example summary"
         app:chromaShapePreview="SQUARE"
         app:chromaColorMode="ARGB"
-        app:chromaInitialColor="#ff0004"/>
+        android:defaultValue="#ff0004"/>
 
-</PreferenceScreen>
+</android.support.v7.preference.PreferenceScreen>


### PR DESCRIPTION
I noticed that using the `defaultValue` attribute didn't work. The library currently uses `chromaInitialColor` but that doesn't work with `PreferenceManager.setDefaultValues`. This fixes that.